### PR TITLE
Added construct and print function objects

### DIFF
--- a/easy.hpp
+++ b/easy.hpp
@@ -30,11 +30,50 @@ namespace detail {
             return gen;
         }
     }
+
+    template <typename T>
+    struct construct_fn {
+        template <typename... Ts>
+        T operator()(Ts&&... ts) const {
+            return T(std::forward<Ts>(ts)...);
+        }
+    };
+
+    struct print_fn {
+        template <typename... Ts>
+        void operator()(Ts&&... ts) const {
+            (std::cout << ... << ts);
+        }
+    };
+
+    template <typename T>
+    struct binded_print_to_fn {
+        T& stream_ref;
+
+        template <typename... Ts>
+        void operator()(Ts&&... ts) const {
+            (stream_ref << ... << ts);
+        }
+    };
+
+    struct print_to_fn {
+        template <typename T>
+        auto operator()(T&& t) const {
+            return binded_print_to_fn<T>(t);
+        }
+    };
 }
 
 namespace easy {
     thread_local std::mt19937_64 random_engine =
             detail::random::get_seeded_generator();
+
+    template <typename T>
+    inline constexpr detail::construct_fn<T> construct;
+
+    inline constexpr detail::print_fn print;
+
+    inline constexpr detail::print_to_fn print_to;
 }
 
 std::ostream& operator<<(

--- a/easy.hpp
+++ b/easy.hpp
@@ -34,14 +34,14 @@ namespace detail {
     template <typename T>
     struct construct_fn {
         template <typename... Ts>
-        T operator()(Ts&&... ts) const {
+        T operator()(Ts&& ... ts) const noexcept(noexcept(T(std::forward<Ts>(ts)...))) {
             return T(std::forward<Ts>(ts)...);
         }
     };
 
     struct print_fn {
         template <typename... Ts>
-        void operator()(Ts&&... ts) const {
+        void operator()(Ts&& ... ts) const {
             (std::cout << ... << ts);
         }
     };
@@ -51,14 +51,14 @@ namespace detail {
         T& stream_ref;
 
         template <typename... Ts>
-        void operator()(Ts&&... ts) const {
+        void operator()(Ts&& ... ts) const {
             (stream_ref << ... << ts);
         }
     };
 
     struct print_to_fn {
         template <typename T>
-        auto operator()(T&& t) const {
+        auto operator()(T&& t) const noexcept {
             return binded_print_to_fn<T>(t);
         }
     };
@@ -95,4 +95,3 @@ std::ostream& operator<<(
 
     return out << ']';
 }
-


### PR DESCRIPTION
The rationale was to create something among the lines of Java's reference to constructor, which simplifies its `Stream::map` (counterpart of `std::ranges::views::transform`) massively. In addition, a utility object for easier printing was added. No more verbose lambdas that simply send something to `std::cout`.

With this utilities added, the famous problem of turning a `.txt` full of 8 characters (`0`s and `1`s) sequences that represent bytes correlating to characters (*and* printing it!) is as trivial as this:

```
int main() {
    using namespace std::ranges;
    std::ifstream input("input.txt");

    for_each(
            istream_view<std::string>(input)
            | views::transform(easy::construct<std::bitset<8>>)
            | views::transform(&std::bitset<8>::to_ulong)
            | views::transform(easy::construct<char>),
            easy::print
    );
}
```